### PR TITLE
manually installed react-scripts + ignoring eslint file

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.eslintcache

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "bootstrap": "^4.6.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-scripts": "4.0.1",
+    "react-scripts": "^4.0.1",
     "web-vitals": "^0.2.4"
   },
   "scripts": {


### PR DESCRIPTION
Finally was able to run the React frontend and also ignored `.eslintcache` file since I think it's generated every time:
```
# updated npm to version 6.14.11

# cleaned the cache in case there was something in there that was conflicting
$ npm cache clean --force

# manually installed react-scripts@4.0.1 -- removed 3 packages, updated 1931 packages, and audited 1934 packages
$ npm i react-scripts
```

Previous error message:
```
$ yarn start
yarn run v1.22.10
$ react-scripts start
'react-scripts' is not recognized as an internal or external command,
operable program or batch file.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```